### PR TITLE
fix: optimize size of logo image at home page

### DIFF
--- a/src/components/HomepageFeatures/index.tsx
+++ b/src/components/HomepageFeatures/index.tsx
@@ -27,7 +27,7 @@ function Feature({title, Img, description}: FeatureItem) {
   return (
     <div className={clsx('col')}>
       <div className="text--center">
-        <img src={useBaseUrl(Img)} />
+        <img src={useBaseUrl(Img)} className={styles.wideLogoImage} />
       </div>
       <div className="text--center padding-horiz--md">
         <Heading as="h3">{title}</Heading>

--- a/src/components/HomepageFeatures/styles.module.css
+++ b/src/components/HomepageFeatures/styles.module.css
@@ -9,3 +9,9 @@
   height: 200px;
   width: 200px;
 }
+
+.wideLogoImage {
+  width: 100%;
+  height: auto;
+  max-width: 600px;
+}


### PR DESCRIPTION
Currently, the logo image on the homepage is too large and needs to be scaled down a bit.

Image size before:
![image](https://github.com/user-attachments/assets/aadc1b36-dc06-4540-97fd-93ab83bd67ca)

Image size now:
![image](https://github.com/user-attachments/assets/54395653-463d-4ff6-8e97-88d935c44363)
